### PR TITLE
SXSG Shaders: Bugfixes

### DIFF
--- a/Shaders/ShadowGenerations/Material/Common_d.ps.hlsl
+++ b/Shaders/ShadowGenerations/Material/Common_d.ps.hlsl
@@ -31,7 +31,7 @@ PixelOutput main(const PixelInput input)
         parameters.albedo *= input.color.rgb;
     }
 
-    AlphaThresholdDiscard(parameters, false);
+    TransparencyDitherDiscardW(parameters);
 
     //////////////////////////////////////////////////
     // Normals

--- a/Shaders/ShadowGenerations/Material/Common_dither_dpn.ps.hlsl
+++ b/Shaders/ShadowGenerations/Material/Common_dither_dpn.ps.hlsl
@@ -35,7 +35,7 @@ PixelOutput main(const PixelInput input)
         parameters.albedo *= input.color.rgb;
     }
 
-    AlphaThresholdDiscard(parameters, true);
+    NoiseDitherDiscardZ(parameters);
 
     //////////////////////////////////////////////////
     // Normals

--- a/Shaders/ShadowGenerations/Material/Common_dn.ps.hlsl
+++ b/Shaders/ShadowGenerations/Material/Common_dn.ps.hlsl
@@ -33,7 +33,7 @@ PixelOutput main(const PixelInput input)
         parameters.albedo *= input.color.rgb;
     }
 
-    AlphaThresholdDiscard(parameters, false);
+    TransparencyDitherDiscardW(parameters);
 
     //////////////////////////////////////////////////
     // Normals

--- a/Shaders/ShadowGenerations/Material/Common_dp.ps.hlsl
+++ b/Shaders/ShadowGenerations/Material/Common_dp.ps.hlsl
@@ -32,7 +32,7 @@ PixelOutput main(const PixelInput input)
         parameters.albedo *= input.color.rgb;
     }
 
-    AlphaThresholdDiscard(parameters, false);
+    TransparencyDitherDiscardW(parameters);
 
     //////////////////////////////////////////////////
     // Normals

--- a/Shaders/ShadowGenerations/Material/Common_dpn.ps.hlsl
+++ b/Shaders/ShadowGenerations/Material/Common_dpn.ps.hlsl
@@ -35,7 +35,7 @@ PixelOutput main(const PixelInput input)
         parameters.albedo *= input.color.rgb;
     }
 
-    AlphaThresholdDiscard(parameters, false);
+    TransparencyDitherDiscardW(parameters);
 
     //////////////////////////////////////////////////
     // Normals

--- a/Shaders/ShadowGenerations/Material/Common_dpna.ps.hlsl
+++ b/Shaders/ShadowGenerations/Material/Common_dpna.ps.hlsl
@@ -37,7 +37,7 @@ PixelOutput main(const PixelInput input)
         parameters.albedo *= input.color.rgb;
     }
 
-    AlphaThresholdDiscard(parameters, false);
+    TransparencyDitherDiscardW(parameters);
 
     //////////////////////////////////////////////////
     // Normals

--- a/Shaders/ShadowGenerations/Material/Common_dpnm.ps.hlsl
+++ b/Shaders/ShadowGenerations/Material/Common_dpnm.ps.hlsl
@@ -36,7 +36,7 @@ PixelOutput main(const PixelInput input)
         parameters.albedo *= input.color.rgb;
     }
 
-    AlphaThresholdDiscard(parameters, false);
+    TransparencyDitherDiscardW(parameters);
 
     //////////////////////////////////////////////////
     // Normals


### PR DESCRIPTION
- Common_dpnm: fixed uv map used for normal texture
- Common_dpnm: fixed how color is applied
- Common_dither_dpn: fixed alpha threshold used